### PR TITLE
Few changes in EmailService

### DIFF
--- a/src/Pixers/SalesManagoAPI/Service/EmailService.php
+++ b/src/Pixers/SalesManagoAPI/Service/EmailService.php
@@ -9,12 +9,32 @@ class EmailService extends AbstractService
 {
     /**
      * Sending SalesManago e-mail.
+     * Even if you set date to current timestamp, keep in mind
+     * that there's around 10min delay due to SalesManago Queuing mechanisms
+     * If you need to send an email immediately, use send method
      *
+     * @param  string $owner Contact owner e-mail address
      * @param  array $data E-mail data
+     *
      * @return array
      */
-    public function create(array $data)
+    public function create($owner, array $data)
     {
+        $data['user'] = $owner;
         return $this->client->doPost('email/send', $data);
+    }
+
+    /**
+     * Immediately send SalesManago email
+     *
+     * @param  string $owner Contact owner e-mail address
+     * @param array $data
+     *
+     * @return array
+     */
+    public function send($owner, array $data)
+    {
+        $data['immediate'] = true;
+        return $this->create($owner, $data);
     }
 }


### PR DESCRIPTION
changed signature of EmailService->create to follow standard presented in ClientService methods - required field account owner is set via parameter, not expected to exist in data array.

added send method (wrapper around create method) to immediately send an email without internal SalesManago queueing
